### PR TITLE
use symbol named "type" from sdl2-ffi package, not the common lisp one

### DIFF
--- a/src/events.lisp
+++ b/src/events.lisp
@@ -124,7 +124,7 @@
      result))
 
 (defun get-event-type (event-ptr)
-  (let ((enum-value (foreign-slot-value event-ptr 'sdl2-ffi:sdl-event 'type)))
+  (let ((enum-value (foreign-slot-value event-ptr 'sdl2-ffi:sdl-event 'sdl2-ffi::type)))
     (foreign-enum-keyword 'event-type enum-value)))
 
 (defun pump-events ()


### PR DESCRIPTION
otherwise sdl2-examples:basic-test is failing with: 

Undefined slot TYPE in foreign type SDL-EVENT.
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME REPL evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT] Abort thread (#<THREAD "repl-thread" RUNNING {1004E20063}>)

Backtrace:
  0: (CFFI::GET-SLOT-INFO SDL2-FFI:SDL-EVENT TYPE)
  1: (FOREIGN-SLOT-VALUE #.(SB-SYS:INT-SAP #X7FFFF2692AD0) SDL2-FFI:SDL-EVENT TYPE)
  2: (GET-EVENT-TYPE #.(SB-SYS:INT-SAP #X7FFFF2692AD0))
  3: (SDL2-EXAMPLES:BASIC-TEST)
  4: (SB-INT:SIMPLE-EVAL-IN-LEXENV (SDL2-EXAMPLES:BASIC-TEST) #<NULL-LEXENV>)
  5: (EVAL (SDL2-EXAMPLES:BASIC-TEST))
 --more--
