### PR TITLE
Fixed a simple error where sdl-show-cursor was being passed CL primitive...

### DIFF
--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -6,10 +6,10 @@
   `(sdl-warp-mouse-in-window win x y))
 
 (defun hide-cursor ()
-  (check-rc (sdl-show-cursor nil)))
+  (check-rc (sdl-show-cursor sdl2-ffi:+sdl-disable+)))
 
 (defun show-cursor ()
-  (check-rc (sdl-show-cursor t)))
+  (check-rc (sdl-show-cursor sdl2-ffi:+sdl-enable+)))
 
 (defun set-relative-mouse-mode (enabled)
   (check-rc (sdl-set-relative-mouse-mode enabled)))


### PR DESCRIPTION
...s

instead of SDl2 primitives.

This fixes a compile error in the head of the repo. 
