### PR TITLE
Enable registering and handling of user defined event types

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -66,10 +66,12 @@
            ;; events.lisp
            #:new-event
            #:free-event
+           #:register-user-event-type
            #:with-sdl-event
            #:get-event-type
            #:pump-events
            #:push-event
+           #:push-user-event
            #:push-quit-event
            #:next-event
            #:with-event-loop


### PR DESCRIPTION
Makes it easy for new user-defined event types to be created and utilized and for lisp data to be associated with these new event types.

Implements two public functions:
- _register-user-event-type_ Which provides an easy way to create new event types
- _push-user-event_ Which provides an easy way to push these new events (and their associated data) onto the message queue

The attached user-data is accessed inside the event-handler via a new :user-data meta parameter.

Example usage:

``` common-lisp
(sdl2:with-init (:everything)
  (sdl2:with-window (win :flags '(:shown :opengl))
    (sdl2:register-user-event-type :example-event-type)
    (sdl2:push-user-event :example-event-type "hello")
    (sdl2:with-event-loop (:method :poll)
      (:example-event-type
        (:user-data data)
        (format t "data ~a accessible here~%" data))))
```

User-data storage implemented using a hashtable sdl2::_user-events_ indexed with integer keys which are stored in the code field of the SDL_UserEvent view of the SDL_Event data structure. The keys are generated using SDL_AtomicIncRef. After an event has been handled its entry in the _user-events_ table is removed.
