### PR TITLE
Add a nice interface to SDL_GetKeyboardState and SDL_GetMouseState

### DIFF
--- a/src/keyboard.lisp
+++ b/src/keyboard.lisp
@@ -41,4 +41,11 @@
   (let ((mask (autowrap:mask-apply 'keymod keywords)))
     (/= 0 (logand mask value))))
 
+(defun keyboard-state-p (scancode)
+  (let ((state (nth-value 1 (autowrap:inhibit-string-conversion
+                              (sdl2-ffi.functions:sdl-get-keyboard-state nil))))
+        (scancode-num (autowrap:enum-value 'sdl2-ffi:sdl-scancode scancode)))
+    (c-let ((state :unsigned-char :ptr state))
+      (= (state scancode-num) 1))))
+
 

--- a/src/keyboard.lisp
+++ b/src/keyboard.lisp
@@ -42,6 +42,7 @@
     (/= 0 (logand mask value))))
 
 (defun keyboard-state-p (scancode)
+  "Whether the key corresponding to the given scancode is currently pressed."
   (let ((state (nth-value 1 (autowrap:inhibit-string-conversion
                               (sdl2-ffi.functions:sdl-get-keyboard-state nil))))
         (scancode-num (autowrap:enum-value 'sdl2-ffi:sdl-scancode scancode)))

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -19,3 +19,14 @@
 
 (defun toggle-relative-mouse-mode ()
   (set-relative-mouse-mode (not (relative-mouse-mode-p))))
+
+(defun mouse-state ()
+  (c-with ((x :int) (y :int))
+    (let ((buttons (sdl2-ffi.functions:sdl-get-mouse-state (x &) (y &))))
+      (values x y buttons))))
+
+(defun mouse-state-p (button)
+  (let ((buttons (sdl2-ffi.functions:sdl-get-mouse-state nil nil))
+        (mask (ash 1 (1- button))))
+    (plusp (logand buttons mask))))
+

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -21,11 +21,16 @@
   (set-relative-mouse-mode (not (relative-mouse-mode-p))))
 
 (defun mouse-state ()
+  "Returns (VALUES X Y BITMASK) where X, Y give the mouse cursor position
+relative to the focused window and BITMASK has bit i from the right set if and
+only if mouse button i is pressed."
   (c-with ((x :int) (y :int))
     (let ((buttons (sdl2-ffi.functions:sdl-get-mouse-state (x &) (y &))))
       (values x y buttons))))
 
 (defun mouse-state-p (button)
+  "Whether the mouse button numbered BUTTON is pressed. 1 indicates the left
+mouse button, 2 the middle mouse button and 3 the right mouse button."
   (let ((buttons (sdl2-ffi.functions:sdl-get-mouse-state nil nil))
         (mask (ash 1 (1- button))))
     (plusp (logand buttons mask))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -98,6 +98,8 @@
            #:set-relative-mouse-mode
            #:relative-mouse-mode-p
            #:toggle-relative-mouse-mode
+           #:mouse-state
+           #:mouse-state-p
 
            ;; joystick.lisp
            #:joystick-update

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -89,6 +89,7 @@
            #:scancode=
            #:mod-keywords
            #:mod-value-p
+           #:keyboard-state-p
 
            ;; mouse.lisp
            #:warp-mouse-in-window


### PR DESCRIPTION
These functions are useful for querying mouse and keyboard state outside the usual event poll mechanism.