### PR TITLE
Added an accessor function to get a pointer to an sdl-surface's raw pixel data

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -204,8 +204,9 @@
            #:rumble-stop
 
            ;; surface.lisp
-	   #:surface-width
-	   #:surface-height
+           #:surface-width
+           #:surface-height
+           #:surface-pixels
            #:create-rgb-surface
            #:create-rgb-surface-from
            #:free-surface

--- a/src/surface.lisp
+++ b/src/surface.lisp
@@ -6,6 +6,10 @@
 (defun surface-height (surface)
   (c-ref surface sdl2-ffi:sdl-surface :h))
 
+(defun surface-pixels (surface)
+  "Access raw pixel data from a surface object"
+  (c-ref surface sdl2-ffi:sdl-surface :pixels))
+
 (defun create-rgb-surface (width height depth
                            &key (r-mask 0) (g-mask 0) (b-mask 0) (a-mask 0)
                            (flags 0))


### PR DESCRIPTION
I needed a way to access the raw pixel data from an sdl-surface that was created from a call to sdl2-image:load-image to texture a quad using opengl. I noticed that while accessors for width and height were available there wasn't any for the pixels field of the struct.

Thought this might be helpful for others