### PR TITLE
.asd: clean up dependencies

### DIFF
--- a/sdl2.asd
+++ b/sdl2.asd
@@ -1,6 +1,6 @@
 ;;;; sdl2.asd
 
-(asdf:defsystem #:sdl2
+(defsystem #:sdl2
   :serial t
   :description "Bindings for SDL2 using c2ffi."
   :author "Chip Collier <photex@lofidelitygames.com>, Ryan Pavlik <rpavlik@gmail.com>, Peter Keller <psilord@cs.wisc.edu>"
@@ -9,9 +9,7 @@
   :depends-on (:alexandria
                :cl-autowrap
                :cl-plus-c
-               :cl-ppcre
                :trivial-garbage
-               :cl-opengl
                :trivial-channels
                #+darwin :cl-glut)
   :pathname "src"
@@ -43,11 +41,13 @@
    (:file "render"
           :depends-on ("rect"))))
 
-(asdf:defsystem #:sdl2-examples
+(defsystem #:sdl2/examples
   :description "simple examples to demonstrate common usage of sdl2."
   :author "Chip Collier <photex@lofidelitygames.com>"
   :license "MIT"
-  :depends-on (:sdl2)
+  :depends-on (:sdl2
+               :cl-opengl
+               :cl-ppcre)
   :pathname "examples"
   :serial t
 

--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -124,9 +124,7 @@ returning an SDL_true into CL's boolean type system."
           (handle-message msg)))
 
 (defun sdl-main-thread ()
-  (let ((*main-thread* (bt:current-thread))
-        #+swank (swank:*sldb-quit-restart* 'continue)
-        #+slynk (slynk:*sly-db-quit-restart* 'continue))
+  (let ((*main-thread* (bt:current-thread)))
     (loop while *main-thread-channel* do
       (block loop-block
         (restart-bind ((continue (lambda (&optional v)


### PR DESCRIPTION
use cl-sdl2/examples naming convention that ASDF treats speciaally.

don't use swank, because the .asd doesn't depend on it, plus it
also wouldn't work if swank was loaded with it's special loader
instead of ASDF.

note that i just blindly moved the extra dependencies to the examples, but didn't check if they are needed there.