### PR TITLE
Added wrapped rwops data structure, fixed surface-format-format return value bug, added a method to see surface pixel format type for debug purposes

### DIFF
--- a/sdl2.asd
+++ b/sdl2.asd
@@ -42,6 +42,7 @@
    (:file "platform")
    (:file "pixels")
    (:file "surface")
+   (:file "rwops")
    (:file "render"
           :depends-on ("rect"))))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -208,6 +208,7 @@
 
            ;; pixels.lisp
            #:map-rgb
+           #:get-pixel-format-name
 
            ;; surface.lisp
            #:surface-width

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -241,6 +241,10 @@
            #:sse-p #:sse2-p #:sse3-p #:sse41-p #:sse42-p
            #:power-info
 
+           ;;rwops.lisp
+           :rw-from-file
+           :rw-close
+
            ;; Utility
            #:sdl-ptr
 

--- a/src/pixels.lisp
+++ b/src/pixels.lisp
@@ -103,3 +103,7 @@
 
 (defun map-rgb (pixel-format r g b)
   (sdl-map-rgb pixel-format r g b))
+
+(defun get-pixel-format-name (format-integer)
+  "Returns the human readable name for a surface's pixel format, useful for debugging."
+  (sdl2-ffi.functions:sdl-get-pixel-format-name format-integer))

--- a/src/rwops.lisp
+++ b/src/rwops.lisp
@@ -1,0 +1,22 @@
+;; SDL2 offers an abstract interface for I/O streams. This file defines bindings operations on RWops including creating RWops structures from files and closing them
+(in-package :sdl2)
+
+(defun %sdl-rw-close (sdl-rwops-ptr)
+  (cffi:foreign-funcall-pointer (plus-c:c-ref sdl-rwops-ptr
+                                              sdl2-ffi:sdl-rwops
+                                              :close)
+                                ()
+                                :pointer sdl-rwops-ptr
+                                :int))
+
+(defun rw-close (sdl-rwops-struct)
+  "Flush the file represented by the sdl-rwops object and free the memory associated with it. Returns 0 if the file is successfully flushed and -1 otherwise. Even if the file fails to flush the memory is freed and pointer is invalid"
+  (tg:cancel-finalization sdl-rwops-struct)
+  (%sdl-rw-close (autowrap:ptr sdl-rwops-struct))
+  (autowrap:invalidate sdl-rwops-struct))
+
+(defun rw-from-file (file-name mode)
+  "Create an RWops structure from a given file name in a given mode."
+  (autowrap:autocollect (ptr)
+      (check-null (sdl-rw-from-file file-name mode))
+    (%sdl-rw-close ptr)))

--- a/src/surface.lisp
+++ b/src/surface.lisp
@@ -14,8 +14,11 @@
   (c-ref surface sdl2-ffi:sdl-surface :format))
 
 (defun surface-format-format (surface)
-  (enum-key '(:enum (sdl-pixel-format))
-            (c-ref surface sdl2-ffi:sdl-surface :format :format)))
+  (c-ref (c-ref surface
+                sdl2-ffi:sdl-surface
+                :format *)
+         sdl2-ffi:sdl-pixel-format
+         :format))
 
 (defun create-rgb-surface (width height depth
                            &key (r-mask 0) (g-mask 0) (b-mask 0) (a-mask 0)


### PR DESCRIPTION
Added a way to create wrapped RWOPs structures which is helpful for some added functionality in cl-sdl2-image. Also surface-format-format returned a struct instead of an integer which gives the enum value of a surface