### PR TITLE
Move two very useful functions into the upstream cl-sdl2 project.

### DIFF
--- a/src/keyboard.lisp
+++ b/src/keyboard.lisp
@@ -19,6 +19,9 @@
   (autowrap:enum-key 'sdl2-ffi:sdl-scancode
                      (scancode-value keysym)))
 
+(defun scancode-symbol (scancode)
+  (autowrap:enum-key 'sdl2-ffi:sdl-scancode scancode))
+
 (defun mod-value (keysym)
   (c-keysym (keysym) (keysym :mod)))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -53,6 +53,7 @@
            #:set-window-position
            #:get-window-title
            #:get-window-size
+           #:get-window-aspect-ratio
            #:get-window-surface
            #:get-window-position
            #:get-window-flags
@@ -94,6 +95,7 @@
            #:key-up-p
            #:scancode-value
            #:scancode
+           #:scancode-symbol
            #:mod-value
            #:sym-value
            #:scancode=

--- a/src/video.lisp
+++ b/src/video.lisp
@@ -162,6 +162,9 @@
     (sdl-get-window-size win width height)
     (values (mem-ref width :int) (mem-ref height :int))))
 
+(defun get-window-aspect-ratio (win)
+  (multiple-value-call #'/ (get-window-size win)))
+
 (defun get-window-surface (win)
   ;; Do NOT free the returned surface.
   (check-null (sdl-get-window-surface win)))


### PR DESCRIPTION
Both functions are simple and currently used in my game engine project.

get-window-aspect-ratio can be used as input for the perspective GL matrix.

scancode-symbol returns the symbol associated with the number, e.g. (sdl2:scancode-symbol 43) returns :SCANCODE-TAB

I fixed the merge issues with pull request #61 by using the up to date cl-sdl2 and doing the changes again in a new commit.