### PR TITLE
Fix extra wait after quit when using :wait method

### DIFF
--- a/src/events.lisp
+++ b/src/events.lisp
@@ -212,10 +212,10 @@ Stores the optional user-data in sdl2::*user-events*"
                   (setf ,idle-func #'(lambda () ,@(expand-idle-handler event-handlers)))
                   (progn ,@(cddr (find :initialize event-handlers :key #'first)))
                   (loop :until ,quit
-                     :do (loop :as ,rc = (next-event ,sdl-event ,method ,timeout)
-                            ,@(if (eq :poll method)
-                                  `(:until (= 0 ,rc))
-                                  `(:until ,quit))
+                     :do (loop
+                            ,@(if (not (eq :poll method)) `(:until ,quit))
+                            :as ,rc = (next-event ,sdl-event ,method ,timeout)
+                            ,@(if (eq :poll method) `(:until (= 0 ,rc)))
                             :do
                             (let* ((,sdl-event-type (get-event-type ,sdl-event))
                                    (,sdl-event-id (and (user-event-type-p ,sdl-event-type)


### PR DESCRIPTION
When using the :wait method for events, the input loop was waiting for input before evaluating the :until form. So when a quit message was received, the application would wait for an extra input before actually quitting.
