### PR TITLE
Fix with-rects

### DIFF
--- a/src/rect.lisp
+++ b/src/rect.lisp
@@ -190,9 +190,9 @@ structures. Raw symbols are bound to (make-rect 0 0 0 0).
       #<SDL-FFI:SDL-RECT x 5 y 10 w 15 h 20>
       #<SDL-FFI:SDL-RECT x 2 y 2 w 3 d 40>)"
   (if (null bindings)
+      `(progn ,@body)
       `(%with-rect (,(car bindings))
-         (with-rects ,(cdr bindings) ,@body))
-      `(progn ,@body)))
+         (with-rects ,(cdr bindings) ,@body))))
 
 (defun rects* (&rest rects)
   "Return a pointer to SDL_Rect and the number of elements in it."


### PR DESCRIPTION
The branches in `with-rects` are in the wrong order, so the macro doesn't work.

```
CL-USER> (sdl2:with-rects () foo)
; in: SDL2:WITH-RECTS ()
;     (LET ((NIL (SDL2:MAKE-RECT 0 0 0 0)))
;       (SDL2:WITH-RECTS NIL
;         FOO))
; 
; caught ERROR:
;   NIL names a defined constant, and cannot be used as a local variable.

CL-USER> (macroexpand-1 '(sdl2:with-rects (foo) foo))
(PROGN FOO)
T
```