### PR TITLE
Fix toggle-relative-mouse-mode

### DIFF
--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -18,7 +18,7 @@
   (sdl-true-p (sdl-get-relative-mouse-mode)))
 
 (defun toggle-relative-mouse-mode ()
-  (set-relative-mouse-mode (not (relative-mouse-mode-p))))
+  (set-relative-mouse-mode (if (relative-mouse-mode-p) 0 1)))
 
 (defun mouse-state ()
   "Returns (VALUES X Y BITMASK) where X, Y give the mouse cursor position


### PR DESCRIPTION
This is a very simple fix. Right now, toggle-relative-mouse-mode errors because it's sending a CL nil or t where a C 0 or 1 is expected.