### PR TITLE
declare syswm as part of system

### DIFF
--- a/sdl2.asd
+++ b/sdl2.asd
@@ -44,6 +44,7 @@
    (:file "events")
    (:file "keyboard")
    (:file "mouse")
+   (:file "syswm")
    (:file "joystick")
    (:file "gamecontroller")
    (:file "haptic")


### PR DESCRIPTION
hello! thanks for this repo. i need `SDL2:GET-WINDOW-WM-INFO` and noticed the file it was defined was not declared as part of the system. this patch adds the declaration :+1: 