### PR TITLE
Fix for allowed return values of #'gl-get-swap-interval.

### DIFF
--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -47,6 +47,13 @@ returning an SDL_true into CL's boolean type system."
          (error 'sdl-rc-error :rc ,rc :string (sdl-get-error)))
        ,rc)))
 
+(defmacro check-not-below (form lower-limit)
+  (with-gensyms (rc)
+    `(let ((,rc ,form))
+       (when (< ,rc ,lower-limit)
+         (error 'sdl-rc-error :rc ,rc :string (sdl-get-error)))
+       ,rc)))
+
 (defmacro check-non-zero (form)
   (with-gensyms (rc)
     `(let ((,rc ,form))

--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -47,13 +47,6 @@ returning an SDL_true into CL's boolean type system."
          (error 'sdl-rc-error :rc ,rc :string (sdl-get-error)))
        ,rc)))
 
-(defmacro check-not-below (form lower-limit)
-  (with-gensyms (rc)
-    `(let ((,rc ,form))
-       (when (< ,rc ,lower-limit)
-         (error 'sdl-rc-error :rc ,rc :string (sdl-get-error)))
-       ,rc)))
-
 (defmacro check-non-zero (form)
   (with-gensyms (rc)
     `(let ((,rc ,form))

--- a/src/video.lisp
+++ b/src/video.lisp
@@ -218,7 +218,7 @@
   (check-rc (sdl-gl-make-current win gl-context)))
 
 (defun gl-get-swap-interval ()
-  (check-rc (sdl-gl-get-swap-interval)))
+  (check-not-below -1 (sdl-gl-get-swap-interval))) ;-1 is an allowed return value, per SDL_GL_GetSwapInterval documentation.
 
 (defun gl-set-swap-interval (interval)
   "0 for immediate updates, 1 for updates synchronized with the vertical retrace"

--- a/src/video.lisp
+++ b/src/video.lisp
@@ -218,7 +218,7 @@
   (check-rc (sdl-gl-make-current win gl-context)))
 
 (defun gl-get-swap-interval ()
-  (check-not-below -1 (sdl-gl-get-swap-interval))) ;-1 is an allowed return value, per SDL_GL_GetSwapInterval documentation.
+  (check-not-below (sdl-gl-get-swap-interval) -1)) ;-1 is an allowed return value, per SDL_GL_GetSwapInterval documentation.
 
 (defun gl-set-swap-interval (interval)
   "0 for immediate updates, 1 for updates synchronized with the vertical retrace"

--- a/src/video.lisp
+++ b/src/video.lisp
@@ -218,7 +218,7 @@
   (check-rc (sdl-gl-make-current win gl-context)))
 
 (defun gl-get-swap-interval ()
-  (check-not-below (sdl-gl-get-swap-interval) -1)) ;-1 is an allowed return value, per SDL_GL_GetSwapInterval documentation.
+  (sdl-gl-get-swap-interval))
 
 (defun gl-set-swap-interval (interval)
   "0 for immediate updates, 1 for updates synchronized with the vertical retrace"


### PR DESCRIPTION
+ added a check-not-below macro

Per [documentation](https://wiki.libsdl.org/SDL_GL_GetSwapInterval), `SDL_GL_GetSwapInterval` can return `-1` when "late swaps happen immediately instead of waiting for the next retrace". It's a valid return value that should not signal an error.