### PR TITLE
Add Accessors for Point Object

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -148,6 +148,8 @@
 
            ;; rect.lisp
            #:make-point
+	   #:point-x
+	   #:point-y
            #:copy-point
            #:copy-into-point
            #:free-point

--- a/src/rect.lisp
+++ b/src/rect.lisp
@@ -15,6 +15,9 @@ collected as needed."
           (point :y) y)
     point))
 
+(define-struct-accessors (point sdl2-ffi:sdl-point)
+  :x :y)
+
 (defmacro c-point ((wrapper-var) &body body)
   `(c-let ((,wrapper-var sdl2-ffi:sdl-point :from ,wrapper-var))
      ,@body))


### PR DESCRIPTION
Add accessors for point object and export them. Before, it was impossible to get the 'x' and 'y' values of a point object without using FFI functions.