### PR TITLE
Use define-package instead of defpackage for ffi packages

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -2,9 +2,9 @@
 
 (push :sdl2 *features*)
 
-(defpackage #:sdl2-ffi)
-(defpackage #:sdl2-ffi.accessors)
-(defpackage #:sdl2-ffi.functions
+(uiop:define-package #:sdl2-ffi)
+(uiop:define-package #:sdl2-ffi.accessors)
+(uiop:define-package #:sdl2-ffi.functions
   (:export #:sdl-quit))
 
 (defpackage #:sdl2


### PR DESCRIPTION
Sometime it is valuable to asdf:load-system with :force t in order to
find warnings. However due to the design of defpackage this will error
as many of the symbols exported for sdl2-ffi* are exported by
c-include.

By moving to define-package we avoid this issue.

Fixes https://github.com/lispgames/cl-sdl2/issues/95