### PR TITLE
Add /usr/X11R6/include to sysincludes on openbsd

### DIFF
--- a/src/autowrap.lisp
+++ b/src/autowrap.lisp
@@ -14,6 +14,7 @@
                     "machine/_types.h"
                     "sys/types.h"
                     "SDL2")
+  :sysincludes `,(append #+openbsd (list "/usr/X11R6/include"))
   :exclude-definitions ("SDL_LogMessageV"
                         "SDL_vsnprintf"
                         "_inline$"


### PR DESCRIPTION
Without this it won't be able to generate a proper spec file