### PR TITLE
Adds a missing function and renderer example improvement

### DIFF
--- a/examples/renderer.lisp
+++ b/examples/renderer.lisp
@@ -1,7 +1,6 @@
 (in-package :sdl2-examples)
 
 (require :sdl2)
-(require :cl-opengl)
 
 (defun test-render-clear (renderer)
   (sdl2:set-render-draw-color renderer 0 0 0 255)
@@ -72,7 +71,7 @@
   "Test the SDL_render.h API"
   (sdl2:with-init (:everything)
     (sdl2:with-window (win :title "SDL2 Renderer API Demo" :flags '(:shown))
-      (sdl2:with-renderer (renderer win :flags '(:renderer-accelerated))
+      (sdl2:with-renderer (renderer win :flags '(:accelerated))
         (sdl2:with-event-loop (:method :poll)
           (:keyup
            (:keysym keysym)
@@ -88,5 +87,6 @@
            (test-render-rects renderer)
            (test-render-fill-rect renderer)
            (test-render-fill-rects renderer)
-           (sdl2:render-present renderer))
+           (sdl2:render-present renderer)
+	   (sdl2:delay 33))
           (:quit () t))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -193,6 +193,7 @@
    #:render-fill-rect
    #:render-fill-rects
    #:set-render-draw-color
+   #:get-render-draw-color
    #:set-texture-blend-mode
    #:set-render-draw-blend-mode
    #:set-render-target

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -113,6 +113,15 @@ rotating it by angle around the given center and also flipping it top-bottom and
   "Use this function to set the color used for drawing operations (Rect, Line and Clear)."
   (check-rc (sdl2-ffi.functions:sdl-set-render-draw-color renderer r g b a)))
 
+(defun get-render-draw-color (renderer)
+  "Use this function to get the current color used by renderer for drawing operations"
+  (c-with ((r sdl2-ffi:uint8)
+	   (g sdl2-ffi:uint8)
+	   (b sdl2-ffi:uint8)
+	   (a sdl2-ffi:uint8))
+    (check-rc (sdl2-ffi.functions:sdl-get-render-draw-color renderer (r &) (g &) (b &) (a &)))
+    (values r g b a)))
+
 (defun set-texture-blend-mode (texture blend-mode)
   "Use this function to set the blend mode for a texture, used by SDL_RenderCopy()."
   (check-rc (sdl2-ffi.functions:sdl-set-texture-blend-mode texture blend-mode)))


### PR DESCRIPTION
- Renderer example improvements
  + there is no need for `cl-opengl`, removed `require` form.
  + renderer flag is `:accelerated` not `:render-accelerated`. fixes #103 .
  + Adds a delay in render loop to relax the CPU a bit.
- Adds the function `sdl2:get-render-draw-color`
(P.S. somehow github shows the wrong indentation in diff, you need to view the whole file to check for indentation.)