### PR TITLE
Adds mouse related functions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.spec linguist-language=commonlisp

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -27,8 +27,23 @@ window and BITMASK has bit i from the right set if and only if mouse button i is
       (values x y buttons))))
 
 (defun mouse-state-p (button)
-  "Whether the mouse button numbered BUTTON is pressed. 1 indicates the left mouse button, 2 the
-middle mouse button and 3 the right mouse button."
+  "Whether the mouse button numbered BUTTON is pressed inside the focused window. 1 indicates the
+left mouse button, 2 the middle mouse button and 3 the right mouse button."
   (let ((buttons (sdl2-ffi.functions:sdl-get-mouse-state nil nil))
+        (mask (ash 1 (1- button))))
+    (plusp (logand buttons mask))))
+
+(defun get-global-mouse-state ()
+  "Returns (X Y BITMASK) where X and Y are positions of the mouse cursor relative to the desktop
+and BITMASK has bit i from the right set if and only if mouse button i is pressed."
+  (c-with ((x :int) (y :int))
+    (let ((buttons (sdl2-ffi.functions:sdl-get-global-mouse-state (x &) (y &))))
+      (values x y buttons))))
+
+(defun global-mouse-state-p (button)
+  "Whether the mouse button numbered BUTTON is pressed. 1 indicates the left mouse button,
+2 the middle mouse button and 3 the right mouse button. This function works relative to desktop
+and can be used even when there is no SDL window open."
+  (let ((buttons (sdl2-ffi.functions:sdl-get-global-mouse-state nil nil))
         (mask (ash 1 (1- button))))
     (plusp (logand buttons mask))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -130,6 +130,8 @@
    #:toggle-relative-mouse-mode
    #:mouse-state
    #:mouse-state-p
+   #:get-global-mouse-state
+   #:global-mouse-state-p
 
    ;; joystick.lisp
    #:joystick-update


### PR DESCRIPTION
- First commit adds .gitattributes file to tell github the repo is common lisp. Without this, repo is marked as a python repo.
- Adds two function `sdl2:get-global-mouse-state` and `sdl2:global-mouse-state-p`. Also corrects the docstring of the function `sdl2:mouse-state-p` to indicate that it works only if the mouse pointer is in a currently focused SDL window.
