### PR TITLE
ensure FFI packages don't use any other packages

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -2,9 +2,10 @@
 
 (push :sdl2 *features*)
 
-(uiop:define-package #:sdl2-ffi)
-(uiop:define-package #:sdl2-ffi.accessors)
+(uiop:define-package #:sdl2-ffi (:use))
+(uiop:define-package #:sdl2-ffi.accessors (:use))
 (uiop:define-package #:sdl2-ffi.functions
+  (:use)
   (:export #:sdl-quit))
 
 (defpackage #:sdl2


### PR DESCRIPTION
In particular, make sure that they don't use the "COMMON-LISP" package
as this could cause trouble, e.g. a C function taking a parameter
named "T".