### PR TITLE
reset the main thread channel on error while joining the main thread

### DIFF
--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -222,7 +222,11 @@ thread."
       (when mtc (sendmsg mtc nil))))
   (when (and *the-main-thread*
              (not (eq *the-main-thread* (bt:current-thread))))
-    (bt:join-thread *the-main-thread*)
+    (handler-case
+        (bt:join-thread *the-main-thread*)
+      (error (e)
+        (declare (ignore e))
+        (setf *main-thread-channel* nil)))
     (setf *the-main-thread* nil))
   (when *the-main-thread*
     (setf *the-main-thread* nil)))


### PR DESCRIPTION
When quitting, it is possible for `*the-main-thread*` to be a stale thread object and as a consequence for `join-thread` to signal an error.  This patch makes sure to catch it and reset the `*main-thread-channel*`, which is also stale, to `nil` so that it can be re-created when needed.