### PR TITLE
Add Constructor and Accessors for `SDL_Color`

### DIFF
--- a/sdl2.asd
+++ b/sdl2.asd
@@ -48,6 +48,7 @@
    (:file "pixels")
    (:file "surface")
    (:file "rwops")
+   (:file "color")
    (:file "render" :depends-on ("rect"))))
 
 (asdf:defsystem #:sdl2/examples

--- a/src/color.lisp
+++ b/src/color.lisp
@@ -1,0 +1,13 @@
+(in-package #:sdl2)
+
+(defun make-rgb-color (r g b a)
+  "Return an SDL_Color filled in with the arguments. It will be garbage collected as needed."
+  (c-let ((color sdl2-ffi:sdl-color))
+    (setf (color :r) r
+	  (color :g) g
+	  (color :b) b
+	  (color :a) a)
+    color))
+
+(define-struct-accessors (color sdl2-ffi:sdl-color)
+  :r :g :b :a)

--- a/src/color.lisp
+++ b/src/color.lisp
@@ -1,6 +1,6 @@
 (in-package #:sdl2)
 
-(defun make-rgb-color (r g b a)
+(defun make-color (r g b a)
   "Return an SDL_Color filled in with the arguments. It will be garbage collected as needed."
   (c-let ((color sdl2-ffi:sdl-color))
     (setf (color :r) r

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -189,6 +189,13 @@
    #:intersect-rect
    #:union-rect
 
+   ;; color.lisp
+   #:make-color
+   #:color-r
+   #:color-g
+   #:color-b
+   #:color-a
+
    ;; render.lisp
    #:render-set-viewport
    #:render-get-viewport


### PR DESCRIPTION
This patch adds the constructor `make-color` and the accessors `color-r`, `color-g`, `color-b`, and `color-a`.

This will be useful when calling `fill-rect` or any other functions that take `SDL_Color` as an argument.

The `SDL_Color` documentation: https://wiki.libsdl.org/SDL_Color