### PR TITLE
Make SDL_TextEditingEvent / SDL_TextInputEvent return string as text

### DIFF
--- a/src/events.lisp
+++ b/src/events.lisp
@@ -171,7 +171,9 @@ Stores the optional user-data in sdl2::*user-events*"
                            :user)))
               (if (eql keyword :user-data)
                   `(,binding (get-user-data (c-ref ,event-var sdl2-ffi:sdl-event ,ref :code)))
-                  `(,binding (c-ref ,event-var sdl2-ffi:sdl-event ,ref ,keyword)))))
+                  (if (and (or (eql ref :text) (eql ref :edit)) (eql keyword :text))
+                      `(,binding (c-ref ,event-var sdl2-ffi:sdl-event ,ref ,keyword string))
+                      `(,binding (c-ref ,event-var sdl2-ffi:sdl-event ,ref ,keyword))))))
           params))
 
 (defun expand-handler (sdl-event event-type params forms)


### PR DESCRIPTION
[SDL_TextEditingEvent](https://wiki.libsdl.org/SDL_TextEditingEvent) / [SDL_TextInputEvent](https://wiki.libsdl.org/SDL_TextInputEvent) both have a data field `text`, which is `char[32]` in C. 

The current implementation returns a `fixnum` in Lisp.

This PR makes them return as a `string`.

I'm not sure if this is appropriate, but I failed to find way to get the `text` without using [sdl2kit](https://github.com/lispgames/sdl2kit). The sdl2kit CLOP approach feels a little overburden for me. So I am looking for a more simple way to get the text.

May you have a good day and be happy.