### PR TITLE
Don't interrupt if the current thread is the main thread

### DIFF
--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -195,7 +195,8 @@ thread."
     #+(and sbcl darwin)
     (let ((thread (sb-thread:main-thread)))
       (setf *the-main-thread* thread)
-      (sb-thread:interrupt-thread thread #'sdl-main-thread))
+      (when (not (eq thread (bt:current-thread)))
+	(sb-thread:interrupt-thread thread #'sdl-main-thread)))
 
   (in-main-thread (:no-event t)
     ;; HACK! glutInit on OSX uses some magic undocumented API to correctly make the calling thread

--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -196,7 +196,7 @@ thread."
     (let ((thread (sb-thread:main-thread)))
       (setf *the-main-thread* thread)
       (when (not (eq thread (bt:current-thread)))
-	(sb-thread:interrupt-thread thread #'sdl-main-thread)))
+        (sb-thread:interrupt-thread thread #'sdl-main-thread)))
 
   (in-main-thread (:no-event t)
     ;; HACK! glutInit on OSX uses some magic undocumented API to correctly make the calling thread


### PR DESCRIPTION
This pull request addresses a problem where the examples don't run on MacOS. The change prevents the main thread from being interrupted.

How to Reproduce with SBCL:

1. (ql:quickload :sdl2/examples)
2. (sdl2:make-this-thread-main #'sdl2-examples:basic-test)