### PR TITLE
Fix slime repl blocked on abort.

### DIFF
--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -111,6 +111,7 @@ into CL's boolean type system."
                    (sdl-quit
                      (lambda (c)
                        (declare (ignore c))
+                       (when chan (sendmsg chan nil))
                        (quit)
                        (return-from handle-message))))
       (handler-bind ((error (lambda (e) (setf condition e))))


### PR DESCRIPTION
Background: When user code goes wrong, e.g. segmentation fault on foreign code, or signaling errors on lisp code, there are always two restarts for users to choose from: 
1. continue, which ignores the errors and continue the code.
2. abort, which quits the sdl entirely.

However, the 2nd restart does not clean up properly and can cause the thread hang forever on a conditional variable, as a result, this can block your slime repl. 
The fix is simple, by explicitly send a message to the channel. 

P.S. I have only ensured the code fixes my problem, but I do not know how it will impact on other parts of the code. I'm not familiar to the fundamentals of cl-sdl, so, thank you first if you can help testing :)