### PR TITLE
 Add with-renderer-draw-color macro 

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -222,6 +222,7 @@
    #:render-fill-rects-f
    #:set-render-draw-color
    #:get-render-draw-color
+   #:with-renderer-draw-color
    #:set-texture-blend-mode
    #:set-render-draw-blend-mode
    #:set-render-target

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -128,6 +128,16 @@ at subpixel precision."
     (check-rc (sdl2-ffi.functions:sdl-get-render-draw-color renderer (r &) (g &) (b &) (a &)))
     (values r g b a)))
 
+(defmacro with-renderer-draw-color ((renderer r g b a) &body body)
+    (let ((rv (gensym))
+          (gv (gensym))
+          (bv (gensym))
+          (av (gensym)))
+    `(multiple-value-bind (,rv ,gv ,bv ,av) (sdl2:get-render-draw-color ,renderer)
+         (sdl2:set-render-draw-color ,renderer ,r ,g ,b ,a)
+         (progn ,@body)
+         (sdl2:set-render-draw-color ,renderer ,rv ,gv ,bv ,av))))
+
 (defun set-texture-blend-mode (texture blend-mode)
   "Use this function to set the blend mode for a texture, used by SDL_RenderCopy()."
   (check-rc (sdl2-ffi.functions:sdl-set-texture-blend-mode texture blend-mode)))

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -129,14 +129,12 @@ at subpixel precision."
     (values r g b a)))
 
 (defmacro with-renderer-draw-color ((renderer r g b a) &body body)
-    (let ((rv (gensym))
-          (gv (gensym))
-          (bv (gensym))
-          (av (gensym)))
+    (with-gensyms (rv gv bv av)
     `(multiple-value-bind (,rv ,gv ,bv ,av) (sdl2:get-render-draw-color ,renderer)
          (sdl2:set-render-draw-color ,renderer ,r ,g ,b ,a)
-         (progn ,@body)
-         (sdl2:set-render-draw-color ,renderer ,rv ,gv ,bv ,av))))
+         (unwind-protect
+              (progn ,@body)
+             (sdl2:set-render-draw-color ,renderer ,rv ,gv ,bv ,av)))))
 
 (defun set-texture-blend-mode (texture blend-mode)
   "Use this function to set the blend mode for a texture, used by SDL_RenderCopy()."

--- a/src/render.lisp
+++ b/src/render.lisp
@@ -129,6 +129,7 @@ at subpixel precision."
     (values r g b a)))
 
 (defmacro with-renderer-draw-color ((renderer r g b a) &body body)
+    "Use this macro to temporary set the color used for drawing operations (Rect, Line and Clear)."
     (with-gensyms (rv gv bv av)
     `(multiple-value-bind (,rv ,gv ,bv ,av) (sdl2:get-render-draw-color ,renderer)
          (sdl2:set-render-draw-color ,renderer ,r ,g ,b ,a)


### PR DESCRIPTION
I wrote a simple game and used colored triangles to draw objects. Each object had its own color, in order to render it, I needed to temporarily change the color of the renderer. That's why I wrote the proposed macro.