### PR TITLE
Fix type error in WITH-F-RECTS

### DIFF
--- a/src/rect.lisp
+++ b/src/rect.lisp
@@ -310,7 +310,7 @@ dest-rect."
 (defmacro %with-f-rect ((binding) &body body)
   (cond
     ((symbolp binding)
-     `(let ((,binding (make-f-rect 0 0 0 0)))
+     `(let ((,binding (make-f-rect 0.0 0.0 0.0 0.0)))
         (unwind-protect (progn ,@body)
           (free-f-rect ,binding))))
     ((= (length binding) 5)


### PR DESCRIPTION
Hello. This tiny PR fixes the following type error in `WITH-F-RECTS` (as seen by SBCL):
```
* (sdl2:with-f-rects (rect))

debugger invoked on a TYPE-ERROR @537B975B in thread
#<THREAD "main thread" RUNNING {1001090113}>:
  The value
    0
  is not of type
    SINGLE-FLOAT
```