### PR TITLE
Split examples package from the main package

### DIFF
--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -1,0 +1,6 @@
+(defpackage #:sdl2-examples
+  (:use #:cl
+        #:alexandria
+        #:cffi)
+  (:export #:basic-test
+           #:renderer-test))

--- a/sdl2.asd
+++ b/sdl2.asd
@@ -63,5 +63,6 @@
   :depends-on (:sdl2 :cl-opengl)
   :pathname "examples"
   :serial t
-  :components ((:file "basic")
+  :components ((:file "package")
+               (:file "basic")
                (:file "renderer")))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -410,10 +410,3 @@
    #:+packedlayout-8888+
    #:+packedlayout-2101010+
    #:+packedlayout-1010102+))
-
-(defpackage #:sdl2-examples
-  (:use #:cl
-        #:alexandria
-        #:cffi)
-  (:export #:basic-test
-           #:renderer-test))


### PR DESCRIPTION
This PR fixes the following little annoying problem: every time `sdl2` system is loaded, it brings `sdl2-examples` with it, even though it is an empty package with no symbols defined. By having separate `package.lisp` from examples, the [sample code](https://github.com/lispgames/cl-sdl2#running-the-sdl2-examples) from readme is still functional, but `sdl2-examples` is not loaded automatically.