### PR TITLE
Add portability - use crossplatform float-features:with-float-traps-masked

### DIFF
--- a/sdl2.asd
+++ b/sdl2.asd
@@ -8,6 +8,7 @@
                :cl-ppcre
                :trivial-channels
                :trivial-features
+               :float-features
                #+darwin :cl-glut)
   :pathname "src"
   :serial t

--- a/src/sdl2.lisp
+++ b/src/sdl2.lisp
@@ -128,15 +128,8 @@ into CL's boolean type system."
         :while msg :do
           (handle-message msg)))
 
-(defmacro without-fp-traps (&body body)
-  #+sbcl
-  `(sb-int:with-float-traps-masked (:underflow :overflow :inexact :invalid :divide-by-zero)
-     ,@body)
-  #-sbcl
-  `(progn ,@body))
-
 (defun sdl-main-thread ()
-  (without-fp-traps
+  (float-features:with-float-traps-masked t
     (let ((*main-thread* (bt:current-thread)))
       (loop :while *main-thread-channel* :do
         (block loop-block


### PR DESCRIPTION
Currently there is a macro `without-fp-traps` defined in sdl2.lisp, which disables signalling float point exceptions on sbcl only. That at the very least causes problems with loading `sketch` on ccl. The same functionality is defined in `float-features` library, but it also works on abcl, ccl, clasp, clisp, cmucl, ecl and mezzano.
 
This library is available in quicklisp and is already an indirect dependency of the `#:sdl2/examples` system (cl-opengl uses it).