### PR TITLE
Add `show-cursor-p` function to sdl2 API wrapper

### DIFF
--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -5,10 +5,18 @@
   `(sdl-warp-mouse-in-window ,win ,x ,y))
 
 (defun hide-cursor ()
+  "Set the cursor to invisible in all SDL2 windows."
   (sdl-true-p (check-rc (sdl-show-cursor sdl2-ffi:+sdl-disable+))))
 
 (defun show-cursor ()
+  "Set the cursor to visible in all SDL2 windows."
   (sdl-true-p (check-rc (sdl-show-cursor sdl2-ffi:+sdl-enable+))))
+
+(defun show-cursor-p ()
+  "Returns whether the cursor is currently visible."
+  (ecase (check-rc (sdl-show-cursor sdl2-ffi:+sdl-query+))
+    (0 nil)
+    (1 t)))
 
 (defun set-relative-mouse-mode (enabled)
   (let ((enabled (ecase enabled ((1 t) 1) ((0 nil) 0))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -134,6 +134,7 @@
    #:warp-mouse-in-window
    #:hide-cursor
    #:show-cursor
+   #:show-cursor-p
    #:set-relative-mouse-mode
    #:relative-mouse-mode-p
    #:toggle-relative-mouse-mode


### PR DESCRIPTION
A very minor CR to improve the show/hide cursor functionality and add a getter function for the current setting.