### PR TITLE
Add gl-get-drawable-size function

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -93,6 +93,7 @@
    #:gl-set-attr
    #:gl-set-attrs
    #:gl-get-proc-address
+   #:gl-get-drawable-size
    #:with-everything
 
    ;; events.lisp

--- a/src/video.lisp
+++ b/src/video.lisp
@@ -230,3 +230,9 @@ Specifying `:windowed` or `:desktop` is \"windowed\" fullscreen, using
 
 (defun gl-get-proc-address (proc-name)
   (sdl-gl-get-proc-address proc-name))
+
+(defun gl-get-drawable-size (win)
+  (c-with ((width :int)
+           (height :int))
+    (sdl-gl-get-drawable-size win (width &) (height &))
+    (list width height)))


### PR DESCRIPTION
Adds a wrapper for SDL_GL_GetDrawableSize(), which is needed to handle hidpi windows.